### PR TITLE
Fixed to use sdkmanager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
 # Jenkins comes with JDK8
 FROM jenkins
 
-# Set desired Android Linux SDK version
-ENV ANDROID_SDK_VERSION 24.4.1
-
-ENV ANDROID_SDK_ZIP android-sdk_r$ANDROID_SDK_VERSION-linux.tgz
-ENV ANDROID_SDK_ZIP_URL https://dl.google.com/android/$ANDROID_SDK_ZIP
+# Set desired Android Linux SDK version's zip file name 
+ENV ANDROID_SDK_ZIP sdk-tools-linux-3859397.zip
+ENV ANDROID_SDK_ZIP_URL https://dl.google.com/android/repository/$ANDROID_SDK_ZIP
 ENV ANDROID_HOME /opt/android-sdk-linux
 
 ENV GRADLE_ZIP gradle-3.0-bin.zip
 ENV GRADLE_ZIP_URL https://services.gradle.org/distributions/$GRADLE_ZIP
 
-ENV PATH $PATH:$ANDROID_HOME/tools
+ENV PATH $PATH:$ANDROID_HOME/tools/bin
 ENV PATH $PATH:$ANDROID_HOME/platform-tools
 ENV PATH $PATH:/opt/gradle-3.0/bin
 
@@ -27,20 +25,20 @@ ADD $GRADLE_ZIP_URL /opt/
 RUN unzip /opt/$GRADLE_ZIP -d /opt/ && \
 	rm /opt/$GRADLE_ZIP
 
+
 # Install Android SDK
 ADD $ANDROID_SDK_ZIP_URL /opt/
-RUN tar xzvf /opt/$ANDROID_SDK_ZIP -C /opt/ && \
+RUN unzip -q /opt/$ANDROID_SDK_ZIP -d $ANDROID_HOME && \
 	rm /opt/$ANDROID_SDK_ZIP
 
 # Install required build-tools
-RUN	echo "y" | android update sdk -u -a --filter platform-tools,android-23,build-tools-23.0.3 && \
-	chmod -R 755 $ANDROID_HOME
-	
-RUN	echo "y" | android update sdk -u -a --filter platform-tools,android-24,build-tools-24.0.1 && \
-	chmod -R 755 $ANDROID_HOME
-
-# Install 32-bit compatibility for 64-bit environments
-RUN apt-get install libc6:i386 libncurses5:i386 libstdc++6:i386 zlib1g:i386 -y
+RUN	echo y | sdkmanager platform-tools \  
+	"build-tools;25.0.0" \ 
+	"platforms;android-25" \
+	"extras;android;m2repository" \
+	"extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2" \
+	"extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2"  && \
+	chown -R jenkins $ANDROID_HOME
 
 # Cleanup
 RUN apt-get clean


### PR DESCRIPTION
The `sdkmanager` command was introduced in SDK Tools 25.2.3 and `android` command is now removed from SDK Tools newer than 25.3.0.

So fixed Dockerfile to use `sdkmanager` instead.

I could not found the way to get 25.2.3 SDK Tools' Download URL from version name,
so used zip name instead. 